### PR TITLE
Adds makefile to the Volere template

### DIFF
--- a/docs/SRS-Volere/Makefile
+++ b/docs/SRS-Volere/Makefile
@@ -1,0 +1,19 @@
+# Makefile
+# From https://danielkaes.wordpress.com/2009/03/14/compiling-latex-documents-using-makefiles/
+
+PROJECT=SRS #SRS or CA
+TEX=pdflatex
+BIBTEX=bibtex
+BUILDTEX=$(TEX) $(PROJECT).tex
+
+all:
+	$(BUILDTEX)
+	$(BIBTEX) $(PROJECT)
+	$(BUILDTEX)
+	$(BUILDTEX)
+
+clean-all:
+	rm -f *.dvi *.log *.bak *.aux *.bbl *.blg *.idx *.ps *.eps *.pdf *.toc *.out *~
+
+clean:
+	rm -f *.log *.bak *.aux *.bbl *.blg *.idx *.toc *.out *.synctex.gz *~


### PR DESCRIPTION
Small PR to setup a makefile for the Volere SRS folder.

Note: There are a few errors related to bibliography since the Volere template doesn't have one set up yet, but it still runs and makes the updated pdf regardless of the errors. Once we set up a bibliography and citations later, the errors should go away:
```
I found no \citation commands---while reading file SRS.aux
I found no \bibdata command---while reading file SRS.aux
I found no \bibstyle command---while reading file SRS.aux
```