### PR TITLE
Adds NFR rationale to some NFRs based on elicitation

### DIFF
--- a/docs/SRS-Volere/SRS.tex
+++ b/docs/SRS-Volere/SRS.tex
@@ -339,7 +339,7 @@ graduate attribute of Lifelong Learning.  Please answer the following questions:
 \section*{Added Section - Appendix - Stakeholder Requirements Elicitation Notes}
 
 \begin{itemize}
-  \item Consider your favourite or most used mobile apps, what elements of the UI
+  \item \textbf{E1:} Consider your favourite or most used mobile apps, what elements of the UI
   stand out? What in your opinion makes an appealing user interface?
     \begin{itemize}
       \item Minimize options to create a cleaner UI.
@@ -348,7 +348,7 @@ graduate attribute of Lifelong Learning.  Please answer the following questions:
       \item Use of icons that clearly convey what the option is meant for.
       \item Put options in consistent locations to minimize hand movements (easy to tap interface).
     \end{itemize}
-  \item When you think of intuitive applications, what about the application makes
+  \item \textbf{E2:} When you think of intuitive applications, what about the application makes
   the UI or UX intuitive?
     \begin{itemize}
       \item Many apps borrow UI layouts from each other, helps with familiarity in terms of navigation.
@@ -357,7 +357,7 @@ graduate attribute of Lifelong Learning.  Please answer the following questions:
       \item Swipe navigation and minimal long presses.
       \item Saving state when closed to minimize user input on future uses.
     \end{itemize}
-  \item How important do you consider application feedback and what feedback would you
+  \item \textbf{E3:} How important do you consider application feedback and what feedback would you
   expect from an application? (i.e. loading indicators)
     \begin{itemize}
       \item High importance to communicate errors and loading to users.
@@ -365,26 +365,26 @@ graduate attribute of Lifelong Learning.  Please answer the following questions:
       \item When fetching information or other longer duration tasks, loading bar should be utilized.
       \item Utilization of messages or pop ups if resources are unavailable or something goes wrong.
     \end{itemize}
-  \item When learning a new app, how long would you consider a reasonable amount of time
+  \item \textbf{E4:} When learning a new app, how long would you consider a reasonable amount of time
   to consider an app easy-to-use?
     \begin{itemize}
       \item Average acceptable time to consider an app intuitive would be to be able to figure
       out basic functionality within 15 minutes.
     \end{itemize}
-  \item What features would you want to help with the learning experience of a new app?
+  \item \textbf{E5:} What features would you want to help with the learning experience of a new app?
     \begin{itemize}
       \item The use of a tutorial on first launch to take users through the UI and different features.
       \item The use of tooltips for certain options and features.
       \item A button that users can press to access a Help menu or FAQ.
     \end{itemize}
-  \item How do you usually go about learning a new application?
+  \item \textbf{E6:} How do you usually go about learning a new application?
     \begin{itemize}
       \item All participants said they tend to brute force applications in order to learn
       (i.e. clicking around and seeing how the application responds).
       \item As an addition to this brute force approach, participants explained how useful an
       undo feature would be as well as always accessible navigation.
     \end{itemize}
-  \item If you were using an application, what personalizations/accessibility settings
+  \item \textbf{E7:} If you were using an application, what personalizations/accessibility settings
   would you consider a must?
     \begin{itemize}
       \item Dark/Light mode.
@@ -393,18 +393,18 @@ graduate attribute of Lifelong Learning.  Please answer the following questions:
       \item Allowing users to enable or disable notifications if used.
       \item Alternate color palettes to help with those with visual impairment like color blindness.
     \end{itemize}
-  \item Consider an app you use often, generally, how long would you say you wait for operations
+  \item \textbf{E8:} Consider an app you use often, generally, how long would you say you wait for operations
   to complete? How long would you be willing to wait for an application before closing the app?
     \begin{itemize}
       \item Ideally, regular operations should take a second or less.
       \item At most, participants would wait an average of 12 seconds before closing the app or
       thinking something went wrong.
     \end{itemize}
-  \item What kind of phone do you use? (Apple/Android/Other)
+  \item \textbf{E9:} What kind of phone do you use? (Apple/Android/Other)
     \begin{itemize}
       \item All participants used Apple devices.
     \end{itemize}
-  \item On a scale of 1-10, for an app of this nature, how important would you consider accuracy
+  \item \textbf{E10:} On a scale of 1-10, for an app of this nature, how important would you consider accuracy
   of the system and data? How important would you consider responsiveness on the same scale?
     \begin{itemize}
       \item All participants considered accuracy of the features and data to be the most important (10) due
@@ -412,7 +412,7 @@ graduate attribute of Lifelong Learning.  Please answer the following questions:
       \item Responsiveness was considered important (8) in order to ensure a positive user experience. If the
       app does not feel good to use, most participants said they would find another app instead.
     \end{itemize}
-  \item How much do you consider the size of an application you install? How big of an app would you
+  \item \textbf{E11:} How much do you consider the size of an application you install? How big of an app would you
   consider reasonable?
     \begin{itemize}
       \item Most participants said they did not pay much attention to the size of applications when installing

--- a/docs/SRS-Volere/SRS.tex
+++ b/docs/SRS-Volere/SRS.tex
@@ -148,22 +148,28 @@ involved in the Project}
 \lips
 
 \section{Look and Feel Requirements}
+In this section, any references to an \textit{E\#} refers elicitation notes in the Appendix. \textit{E\#} corresponds
+to the label for the relevant question.
+
 \subsection{Appearance Requirements}
 \begin{itemize}
-  \item \textbf{AR1}: The app should have a consistent colour scheme throughout.
-  \item \textbf{AR2}: The app should have self-descriptive icons to convey to users what the related feature is.
-  \item \textbf{AR3}: The user interface should avoid clutter and balance features with available space.
+  \item \textbf{AR1}: The app should have a consistent colour scheme throughout as requested in \textit{E1}.
+  \item \textbf{AR2}: The app should have self-descriptive icons to convey to users what the related feature is as requested in \textit{E1}.
+  \item \textbf{AR3}: The user interface should avoid clutter and balance features with available space as requested in \textit{E1}.
 \end{itemize}
 \subsection{Style Requirements}
 \begin{itemize}
-  \item \textbf{SR1}: All app features and options should be in consistent locations.
-  \item \textbf{SR2}: Navigation options should always be available regardless of the application page.
+  \item \textbf{SR1}: All app features and options should be in consistent locations as requested in \textit{E1}.
+  \item \textbf{SR2}: Navigation options should always be available regardless of the application page as requested in \textit{E6}.
   \item \textbf{SR3}: Features and options should be grouped based on relation to each other to improve intuitiveness.
   \item \textbf{SR4}: The number of clicks to access different features should be minimized.
-  \item \textbf{SR5}: The app should utilize indicators and messages to communicate information to users.
+  \item \textbf{SR5}: The app should utilize indicators and messages to communicate information to users as requested in \textit{E3}.
 \end{itemize}
 
 \section{Usability and Humanity Requirements}
+In this section, any references to an \textit{E\#} refers elicitation notes in the Appendix. \textit{E\#} corresponds
+to the label for the relevant question.
+
 \subsection{Ease of Use Requirements}
 \begin{itemize}
   \item \textbf{EUR1}: The app should save states between use in order to minimize user input.
@@ -172,14 +178,14 @@ involved in the Project}
 \subsection{Personalization and Internationalization Requirements}
 \begin{itemize}
   \item \textbf{PIR1}: English will be supported.
-  \item \textbf{PIR2}: The app should have dark and light mode colour schemes.
-  \item \textbf{PIR3}: The app should allow users to enable/disable external notifications.
+  \item \textbf{PIR2}: The app should have dark and light mode colour schemes as requested in \textit{E7}.
+  \item \textbf{PIR3}: The app should allow users to enable/disable external notifications as requested in \textit{E7}.
 \end{itemize}
 \subsection{Learning Requirements}
 \begin{itemize}
-  \item \textbf{LR1}: The app should have an FAQ or Help page to assist users.
+  \item \textbf{LR1}: The app should have an FAQ or Help page to assist users as requested in \textit{E5}.
   \item \textbf{LR2}: The app should have a tutorial to assist users in learning the available
-  features.
+  features as requested in \textit{E5}.
 \end{itemize}
 \subsection{Understandability and Politeness Requirements}
 \begin{itemize}
@@ -187,16 +193,21 @@ involved in the Project}
 \end{itemize}
 \subsection{Accessibility Requirements}
 \begin{itemize}
-  \item \textbf{ACR1}: The app should allow users to change text size.
-  \item \textbf{ACR2}: The app should have multiple colour schemes to help those with visual impairment.
+  \item \textbf{ACR1}: The app should allow users to change text size as requested in \textit{E7}.
+  \item \textbf{ACR2}: The app should have multiple colour schemes to help those with visual impairment
+  as requested in \textit{E7}.
 \end{itemize}
 
 \section{Performance Requirements}
+In this section, any references to an \textit{E\#} refers elicitation notes in the Appendix. \textit{E\#} corresponds
+to the label for the relevant question.
+
 \subsection{Speed and Latency Requirements}
 \begin{itemize}
   \item \textbf{SLR1}: The app should take on average 1 second to complete backend tasks and at worst should never
-  exceed 12 seconds.
-  \item \textbf{SLR2}: The navigation of the app should be smooth, taking no more than 1 second render and handle page changes.
+  exceed 12 seconds as elicited in \textit{E8}.
+  \item \textbf{SLR2}: The navigation of the app should be smooth, taking no more than 1 second render and handle page changes
+  as elicited in \textit{E8}.
 \end{itemize}
 \subsection{Safety-Critical Requirements}
 \begin{itemize}
@@ -204,16 +215,19 @@ involved in the Project}
 \end{itemize}
 \subsection{Precision or Accuracy Requirements}
 \begin{itemize}
-  \item \textbf{PAR1}: The app should be able to correctly read user inputs with 99\% accuracy.
-  \item \textbf{PAR2}: The app should return data to the user with correctness within 99\% of the intended value.
+  \item \textbf{PAR1}: The app should be able to correctly read user inputs with 99\% accuracy as elicited
+  in \textit{E10}.
+  \item \textbf{PAR2}: The app should return data to the user with correctness within 99\% of the intended value
+  as elicited in \textit{E10}.
 \end{itemize}
 \subsection{Robustness or Fault-Tolerance Requirements}
 \begin{itemize}
-  \item \textbf{RFR1}: The app should have proper error-handling against improper user input.
+  \item \textbf{RFR1}: The app should have proper error-handling against improper user input to account for
+  experimentation as elicited in \textit{E6}.
 \end{itemize}
 \subsection{Capacity Requirements}
 \begin{itemize}
-  \item \textbf{CR1}: The app should take up no more than 1GB of space.
+  \item \textbf{CR1}: The app should take up no more than 1GB of space as elicited in \textit{E11}.
 \end{itemize}
 \subsection{Scalability or Extensibility Requirements}
 \begin{itemize}


### PR DESCRIPTION
03/10/23

# Adds NFR rationale to some NFRs based on elicitation

This was an adhoc PR made after reading through the rubric again. Part of the rubric is to rationalize some less obvious or less straightforward requirements/design decisions. Since many of mine come from elicitations, I asked Chris how rationalization/traceability should be done and he said to label the elicitations in the Appendix and reference them in the NFRs that I need to. This PR adds those labels and rationale.

![image](https://github.com/r-yeh/grocery-spending-tracker/assets/67233377/98871f88-6783-490b-8014-ed76221779aa)

The NFRs themselves remain unchanged, "pointers" to the appendix were simply added in the form of "as requested in E#" or as elicited in "E#". Additionally, not all of the NFRs were rationalized, only some of the ones that seemed less obvious such as the numbers I used in Performance NFRs or some of the Look and Feel Requirements.

### Changelog
- Section 10
- Section 11
- Section 12
- Appendix

### Notes