### PR TITLE
Issue #172: VnV Terminology and Introduction

### DIFF
--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -119,7 +119,8 @@ In general, a majority of the requirements set by the
 \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/SRS/SRS.pdf}{SRS} and
 \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/HazardAnalysis/HazardAnalysis.pdf}{HA} will be considered
 during validation and verification. Maintainability, adaptability, and compliance tests however will be placed out of scope
-due to them having less direct impact on the main user experience. The primary focus during
+due to them having less direct impact on the main user experience. Additionally, personalization settings
+will be out of scope for testing as well due to them having less importance for the current build of the project. The primary focus during
 this development period will be to build a prototype application with all primary features and qualities rather than a
 full consumer product. With this in mind, these qualities seemed less relevant to this overall goal.
 Additionally, several features will leverage external libraries as part of the overall workflow and these components will

--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -69,55 +69,87 @@ in.}
   \toprule		
   \textbf{symbol} & \textbf{description}\\
   \midrule 
-  T & Test\\
+  SRS & Software Requirements Specification\\
+  OCR & Optical Character Recognition\\
+  HA & Hazard Analysis\\
+  VnV & Verification and Validation\\
+  MG & Moduel Guide\\
   \bottomrule
 \end{tabular}\\
-
-\wss{symbols, abbreviations, or acronyms --- you can simply reference the SRS
-  \citep{SRS} tables, if appropriate}
-
-\wss{Remove this section if it isn't needed}
 
 \newpage
 
 \pagenumbering{arabic}
 
-This document ... \wss{provide an introductory blurb and roadmap of the
-  Verification and Validation plan}
+This document outlines the verification and validation plan for the Grocery Spending Tracker.
+The document will cover some basic information about the application as well as go over the plans
+the team has for testing its requirements and features throughout development. It will also cover
+the different system tests and unit tests that the team will employ to go about validating
+the software.
 
 \section{General Information}
 
+This section will give a general overview of the application as well as the objectives
+the team has for performing validation and verification. This section will also include any
+relevant document related to the overall testing plan.
+
 \subsection{Summary}
 
-\wss{Say what software is being tested.  Give its name and a brief overview of
-  its general functions.}
+The Grocery Spending Tracker is a mobile application being developed to help
+users save money on groceries. The main feature is allowing users to input photos of receipts
+which the application will then parse. Once parsed, the items and their corresponding prices will then be recorded.
+This data will then be used to show analytics regarding their purchase history over time.
+Additionally, the application will also allow users to get budgeting suggestions based on personal spending preferences
+as well as recommendations for alternative nearby grocery stores where recently purchased items
+can be obtained for cheaper.
 
 \subsection{Objectives}
 
-\wss{State what is intended to be accomplished.  The objective will be around
-  the qualities that are most important for your project.  You might have
-  something like: ``build confidence in the software correctness,''
-  ``demonstrate adequate usability.'' etc.  You won't list all of the qualities,
-  just those that are most important.}
+In regards to the application's primary functionality, testing will be done to build confidence
+in the correctness and accuracy of all main features such as the OCR for receipt input as well as analytic
+data being returned. This also holds for any budgeting suggestions and alternative grocery store suggestions.
+Due to the nature of this application focusing on user finances, the accuracy and correctness of all
+main features are paramount to this application's success.
+Additionally, qualities that are important for an enjoyable user experience
+will also be emphasized in this VnV Plan. Testing should verify that the application demonstrates
+acceptable levels of usability and performance according to stakeholder expectations. \\
 
-\wss{You should also list the objectives that are out of scope.  You don't have 
-the resources to do everything, so what will you be leaving out.  For instance, 
-if you are not going to verify the quality of usability, state this.  It is also 
-worthwhile to justify why the objectives are left out.}
-
-\wss{The objectives are important because they highlight that you are aware of 
-limitations in your resources for verification and validation.  You can't do everything, 
-so what are you going to prioritize?  As an example, if your system depends on an 
-external library, you can explicitly state that you will assume that external library 
-has already been verified by its implementation team.}
+In general, a majority of the requirements set by the
+\href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/SRS/SRS.pdf}{SRS} and
+\href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/HazardAnalysis/HazardAnalysis.pdf}{HA} will be considered
+during validation and verification. Maintainability, adaptability, and compliance tests however will be placed out of scope
+due to them having less direct impact on the main user experience. The primary focus during
+this development period will be to build a prototype application with all primary features and qualities rather than a
+full consumer product. With this in mind, these qualities seemed less relevant to this overall goal.
+Additionally, several features will leverage external libraries as part of the overall workflow and these components will
+be excluded from testing as well on a unit level. The team will assume that these libraries have already
+been tested extensively by the original developers and other users.
 
 \subsection{Relevant Documentation}
 
-\wss{Reference relevant documentation.  This will definitely include your SRS
-  and your other project documents (design documents, like MG, MIS, etc).  You
-  can include these even before they are written, since by the time the project
-  is done, they will be written.}
+% \wss{Reference relevant documentation.  This will definitely include your SRS
+%   and your other project documents (design documents, like MG, MIS, etc).  You
+%   can include these even before they are written, since by the time the project
+%   is done, they will be written.}
 
+Listed below are the relevant documents referred to in this VnV Plan:
+
+\begin{itemize}
+  \item \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/SRS/SRS.pdf}{Software Requirements Specification} \citet{GrocerySRS}
+  \begin{itemize}
+    \item The SRS contains the primary functional and non-functional requirements that are being used as the basis for many of the tests
+    in this document.
+  \end{itemize}
+  \item \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/HazardAnalysis/HazardAnalysis.pdf}{Hazard Analysis} \citet{GroceryHA}
+  \begin{itemize}
+    \item The HA contains a number of safety requirements that were identified to help mitigate risk that were also considered
+    for testing in this document.
+  \end{itemize}
+  \item \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/Design/SoftArchitecture/MG.pdf}{Module Guide}
+  \begin{itemize}
+    \item The MG references the different modules that make up the overall application in which the VnV Plan tests.
+  \end{itemize}
+\end{itemize}
 \citet{SRS}
 
 \wss{Don't just list the other documents.  You should explain why they are relevant and 

--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -74,6 +74,7 @@ in.}
   HA & Hazard Analysis\\
   VnV & Verification and Validation\\
   MG & Module Guide\\
+  MIS & Module Interface Specification\\
   \bottomrule
 \end{tabular}\\
 
@@ -147,13 +148,13 @@ Listed below are the relevant documents referred to in this VnV Plan:
   \end{itemize}
   \item \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/Design/SoftArchitecture/MG.pdf}{Module Guide}
   \begin{itemize}
-    \item The MG references the different modules that make up the overall application in which the VnV Plan tests.
+    \item The MG references the different modules that make up the general overall application in which the VnV Plan tests.
+  \end{itemize}
+  \item \href{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/Design/SoftDetailedDes/MIS.pdf}{Module Interface Specification}
+  \begin{itemize}
+    \item The MIS contains detailed information on each of the application modules which form the basis for the unit tests.
   \end{itemize}
 \end{itemize}
-\citet{SRS}
-
-\wss{Don't just list the other documents.  You should explain why they are relevant and 
-how they relate to your VnV efforts.}
 
 \section{Plan}
 

--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -64,6 +64,9 @@ in.}
 
 \section{Symbols, Abbreviations, and Acronyms}
 
+This section will include any symbols, abbreviations and acronyms
+used in this document and their definitions. \\
+
 \renewcommand{\arraystretch}{1.2}
 \begin{tabular}{l l} 
   \toprule		

--- a/docs/VnVPlan/VnVPlan.tex
+++ b/docs/VnVPlan/VnVPlan.tex
@@ -73,7 +73,7 @@ in.}
   OCR & Optical Character Recognition\\
   HA & Hazard Analysis\\
   VnV & Verification and Validation\\
-  MG & Moduel Guide\\
+  MG & Module Guide\\
   \bottomrule
 \end{tabular}\\
 

--- a/refs/References.bib
+++ b/refs/References.bib
@@ -187,3 +187,19 @@
 	volume = {12},
 	year = {February 1986},
 	bdsk-file-1 = {YnBsaXN0MDDSAQIDBFxyZWxhdGl2ZVBhdGhZYWxpYXNEYXRhXxBALi4vLi4vLi4vc2U0c2MvU2NpQ29tcEFuZFNvZnRFbmdQYXBlcnMvUGFybmFzQW5kQ2xlbWVudHMxOTg2LnBkZk8RAfYAAAAAAfYAAgAADE1hY2ludG9zaCBIRAAAAAAAAAAAAAAAAAAAAM6Xc4NIKwAACTH9DRlQYXJuYXNBbmRDbGVtZW50czE5ODYucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJMf1D028E0wAAAAAAAAAAAAMAAwAACSAAAAAAAAAAAAAAAAAAAAAXU2NpQ29tcEFuZFNvZnRFbmdQYXBlcnMAABAACAAAzperwwAAABEACAAA0289EwAAAAEAFAkx/Q0JMe7HABIVpwAI92YAAmSOAAIAXE1hY2ludG9zaCBIRDpVc2VyczoAc21pdGhzOgBSZXBvczoAc2U0c2M6AFNjaUNvbXBBbmRTb2Z0RW5nUGFwZXJzOgBQYXJuYXNBbmRDbGVtZW50czE5ODYucGRmAA4ANAAZAFAAYQByAG4AYQBzAEEAbgBkAEMAbABlAG0AZQBuAHQAcwAxADkAOAA2AC4AcABkAGYADwAaAAwATQBhAGMAaQBuAHQAbwBzAGgAIABIAEQAEgBKVXNlcnMvc21pdGhzL1JlcG9zL3NlNHNjL1NjaUNvbXBBbmRTb2Z0RW5nUGFwZXJzL1Bhcm5hc0FuZENsZW1lbnRzMTk4Ni5wZGYAEwABLwAAFQACAA3//wAAAAgADQAaACQAZwAAAAAAAAIBAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAJh}}
+
+@misc{GrocerySRS,
+	Author = {Jason Nam and Allan Fang and Sawyer Tang and Ryan Yeh},
+	Date-Added = {2023-10-06 23:59:59 -0500},
+	Date-Modified = {2023-10-06 23:59:59 -0500},
+	Howpublished = {\url{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/SRS/SRS.pdf}},
+	Title = {Software Requirements Specification},
+	Year = {2023}}
+
+@misc{GroceryHA,
+	Author = {Jason Nam and Allan Fang and Sawyer Tang and Ryan Yeh},
+	Date-Added = {2023-10-19 23:59:59 -0500},
+	Date-Modified = {2023-10-19 23:59:59 -0500},
+	Howpublished = {\url{https://github.com/r-yeh/grocery-spending-tracker/blob/master/docs/HazardAnalysis/HazardAnalysis.pdf}},
+	Title = {Hazard Analysis},
+	Year = {2023}}


### PR DESCRIPTION
26/10/23

# Issue #172: Wrote initial VnV Terminology and Introduction

This adds some initial terminology and an initial version of the Introductory section of the VnV document. This also adds some entries to the References document which are required for citing other documents in our repo as required by the Relevant Documents section.

### Changelog
- References
- Section 1 of VnV
- Section 2 of VnV

### Notes
- I think Section 1 is different enough that I don't want to just directly reference the SRS. If you have any terms or abbreviations you end up using for your sections, please add them to the table