### PR TITLE
Issue #254: MG Module Traceability

### DIFF
--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -308,8 +308,8 @@ requirements and between the modules and the anticipated changes.
 \toprule
 \textbf{Req.} & \textbf{Modules}\\
 \midrule
-FR1 & \mref{mAuthentication}\\
-FR2 & \mref{mAuthentication}, \mref{mDBDriver}\\
+FR1 & \mref{mAuth}\\
+FR2 & \mref{mAuth}, \mref{mDBDriver}\\
 FR3 & \mref{mRVision}\\
 FR4 & \mref{mLocation}, \mref{mUsers}, \mref{mDBDriver}\\
 FR5 & \mref{mUsers}, \mref{mDBDriver}\\
@@ -318,54 +318,54 @@ FR7 & \mref{mClassification}, \mref{mDBDriver}\\
 FR8 & \mref{mRec}, \mref{mDBDriver}\\
 FR9 & \mref{mRec}, \mref{mDBDriver}\\
 FR10 & \mref{mAnalytics}, \mref{mDBDriver}\\
-FR11 & \mref{mExtraction}\\
+FR11 & \mref{mReview}\\
 FR12 & \mref{mClassification}, \mref{mDBDriver}\\
-AR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-AR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-AR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-SR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-SR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-SR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-EUR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-EUR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-EUR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-PIR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-PIR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+AR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+AR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+AR3 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+SR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+SR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+SR3 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+EUR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+EUR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+EUR3 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+PIR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+PIR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
 PIR3 & \mref{mUsers}\\
-LR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-LR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-UPR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-UPR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-ACR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-ACR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-SLR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-SLR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-PAR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation},\mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}\\
+LR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+LR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+UPR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+UPR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+ACR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+ACR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+SLR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+SLR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+PAR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation},\mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}\\
 PAR2 & \mref{mAnalytics}\\
-RFR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation},\mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}\\
-CR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-EPER1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-EPER2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-EPER3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+RFR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation},\mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}\\
+CR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+EPER1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+EPER2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+EPER3 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
 WER1 & \mref{mRVision}\\
-WER2 & \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-IASR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-IASR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-SPR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
-SPR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-APR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-APR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-ACR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-INR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-INR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-PRR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-PRR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-AUR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-CUR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-CUR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-CUR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-LR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
-LR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+WER2 & \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+IASR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+IASR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+SPR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
+SPR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+APR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+APR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+ACR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+INR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+INR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+PRR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+PRR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+AUR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+CUR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+CUR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+CUR3 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+LR1 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+LR2 & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
 \bottomrule
 \caption{Trace Between Requirements and Modules}
 \label{TblRT}
@@ -378,10 +378,10 @@ LR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, 
 \textbf{AC} & \textbf{Modules}\\
 \midrule
 \acref{acHardware} & \mref{mHH}\\
-\acref{acInput} & \mref{mRVision}, \mref{mExtraction}\\
-\acref{acAPIReq} & \mref{mExtraction}, \mref{mLocation}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-\acref{acAPIRes} & \mref{mAnalytics}, \mref{mLocation}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
-\acref{acFormat} & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+\acref{acInput} & \mref{mRVision}, \mref{mReview}\\
+\acref{acAPIReq} & \mref{mReview}, \mref{mLocation}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+\acref{acAPIRes} & \mref{mAnalytics}, \mref{mLocation}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}, \mref{mClassification}\\
+\acref{acFormat} & \mref{mRVision}, \mref{mReview}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuth}, \mref{mRec}\\
 \acref{acDB} & \mref{mDBDriver}\\
 \bottomrule
 \end{tabular}

--- a/docs/Design/SoftArchitecture/MG.tex
+++ b/docs/Design/SoftArchitecture/MG.tex
@@ -8,6 +8,7 @@
 \usepackage{graphicx}
 \usepackage{float}
 \usepackage{hyperref}
+\usepackage{longtable}
 \hypersetup{
     colorlinks,
     citecolor=blue,
@@ -303,28 +304,72 @@ requirements and between the modules and the anticipated changes.
 
 % the table should use mref, the requirements should be named, use something
 % like fref
-\begin{table}[H]
-\centering
-\begin{tabular}{p{0.2\textwidth} p{0.6\textwidth}}
+\begin{longtable}{p{0.2\textwidth} p{0.6\textwidth}}
 \toprule
 \textbf{Req.} & \textbf{Modules}\\
 \midrule
-R1 & \mref{mHH}, \mref{mInput}, \mref{mParams}, \mref{mControl}\\
-R2 & \mref{mInput}, \mref{mParams}\\
-R3 & \mref{mVerify}\\
-R4 & \mref{mOutput}, \mref{mControl}\\
-R5 & \mref{mOutput}, \mref{mODEs}, \mref{mControl}, \mref{mSeqDS}, \mref{mSolver}, \mref{mPlot}\\
-R6 & \mref{mOutput}, \mref{mODEs}, \mref{mControl}, \mref{mSeqDS}, \mref{mSolver}, \mref{mPlot}\\
-R7 & \mref{mOutput}, \mref{mEnergy}, \mref{mControl}, \mref{mSeqDS}, \mref{mPlot}\\
-R8 & \mref{mOutput}, \mref{mEnergy}, \mref{mControl}, \mref{mSeqDS}, \mref{mPlot}\\
-R9 & \mref{mVerifyOut}\\
-R10 & \mref{mOutput}, \mref{mODEs}, \mref{mControl}\\
-R11 & \mref{mOutput}, \mref{mODEs}, \mref{mEnergy}, \mref{mControl}\\
+FR1 & \mref{mAuthentication}\\
+FR2 & \mref{mAuthentication}, \mref{mDBDriver}\\
+FR3 & \mref{mRVision}\\
+FR4 & \mref{mLocation}, \mref{mUsers}, \mref{mDBDriver}\\
+FR5 & \mref{mUsers}, \mref{mDBDriver}\\
+FR6 & \mref{mUsers}, \mref{mDBDriver}\\
+FR7 & \mref{mClassification}, \mref{mDBDriver}\\
+FR8 & \mref{mRec}, \mref{mDBDriver}\\
+FR9 & \mref{mRec}, \mref{mDBDriver}\\
+FR10 & \mref{mAnalytics}, \mref{mDBDriver}\\
+FR11 & \mref{mExtraction}\\
+FR12 & \mref{mClassification}, \mref{mDBDriver}\\
+AR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+AR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+AR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+SR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+SR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+SR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+EUR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+EUR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+EUR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+PIR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+PIR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+PIR3 & \mref{mUsers}\\
+LR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+LR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+UPR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+UPR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+ACR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+ACR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+SLR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+SLR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+PAR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation},\mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}\\
+PAR2 & \mref{mAnalytics}\\
+RFR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation},\mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}\\
+CR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+EPER1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+EPER2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+EPER3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+WER1 & \mref{mRVision}\\
+WER2 & \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+IASR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+IASR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+SPR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+SPR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+APR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+APR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+ACR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+INR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+INR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+PRR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+PRR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+AUR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+CUR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+CUR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+CUR3 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+LR1 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
+LR2 & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}, \mref{mDBDriver}\\
 \bottomrule
-\end{tabular}
 \caption{Trace Between Requirements and Modules}
 \label{TblRT}
-\end{table}
+\end{longtable}
 
 \begin{table}[H]
 \centering
@@ -333,17 +378,11 @@ R11 & \mref{mOutput}, \mref{mODEs}, \mref{mEnergy}, \mref{mControl}\\
 \textbf{AC} & \textbf{Modules}\\
 \midrule
 \acref{acHardware} & \mref{mHH}\\
-\acref{acInput} & \mref{mInput}\\
-\acref{acParams} & \mref{mParams}\\
-\acref{acVerify} & \mref{mVerify}\\
-\acref{acOutput} & \mref{mOutput}\\
-\acref{acVerifyOut} & \mref{mVerifyOut}\\
-\acref{acODEs} & \mref{mODEs}\\
-\acref{acEnergy} & \mref{mEnergy}\\
-\acref{acControl} & \mref{mControl}\\
-\acref{acSeqDS} & \mref{mSeqDS}\\
-\acref{acSolver} & \mref{mSolver}\\
-\acref{acPlot} & \mref{mPlot}\\
+\acref{acInput} & \mref{mRVision}, \mref{mExtraction}\\
+\acref{acAPIReq} & \mref{mExtraction}, \mref{mLocation}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+\acref{acAPIRes} & \mref{mAnalytics}, \mref{mLocation}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}, \mref{mClassification}\\
+\acref{acFormat} & \mref{mRVision}, \mref{mExtraction}, \mref{mLocation}, \mref{mAnalytics}, \mref{mUsers}, \mref{mAuthentication}, \mref{mRec}\\
+\acref{acDB} & \mref{mDBDriver}\\
 \bottomrule
 \end{tabular}
 \caption{Trace Between Anticipated Changes and Modules}


### PR DESCRIPTION
09/01/24

# Issue #254: MG Module Traceability

Adds traceability tables for all relevant requirements (FRs and NFRs) and anticipated changes.

### Changelog
- Section 8

### Notes
- The names of label IDs currently used are subject to change, so some changes will be made prior to the merge to ensure that the label IDs (`mName`) match what is used in the other sections of the document.
- There was also a comment left by Dr. Smith at the top saying something about using fref to reference requirements but I'm not sure what that means so may need to change that later