### PR TITLE
Issue #265: MIS for Receipt Vision Module

### DIFF
--- a/docs/Design/SoftDetailedDes/MIS.tex
+++ b/docs/Design/SoftDetailedDes/MIS.tex
@@ -229,6 +229,79 @@ The following table is taken directly from the Module Guide document for this pr
 
 \newpage
 
+\section{MIS of Receipt Vision Module} \label{mVision}
+
+The Receipt Vision Module is responsible for providing methods and logic related to image
+capture of the receipt. This includes responsibilities like handling device permissions and camera access.
+
+\subsection{Module}
+
+receiptVision
+
+\subsection{Uses}
+
+None
+
+\subsection{Syntax}
+
+\subsubsection{Exported Constants}
+
+None
+
+\subsubsection{Exported Access Programs}
+
+\begin{center}
+\begin{tabular}{p{2cm} p{4cm} p{4cm} p{2cm}}
+\hline
+\textbf{Name} & \textbf{In} & \textbf{Out} & \textbf{Exceptions} \\
+\hline
+\wss{accessProg} & - & - & - \\
+\hline
+\end{tabular}
+\end{center}
+
+\subsection{Semantics}
+
+\subsubsection{State Variables}
+
+\wss{Not all modules will have state variables.  State variables give the module
+  a memory.}
+
+\subsubsection{Environment Variables}
+
+User Camera \\
+User Display
+
+\subsubsection{Assumptions}
+
+\wss{Try to minimize assumptions and anticipate programmer errors via
+  exceptions, but for practical purposes assumptions are sometimes appropriate.}
+
+\subsubsection{Access Routine Semantics}
+
+\noindent \wss{accessProg}():
+\begin{itemize}
+\item transition: \wss{if appropriate} 
+\item output: \wss{if appropriate} 
+\item exception: \wss{if appropriate} 
+\end{itemize}
+
+\wss{A module without environment variables or state variables is unlikely to
+  have a state transition.  In this case a state transition can only occur if
+  the module is changing the state of another module.}
+
+\wss{Modules rarely have both a transition and an output.  In most cases you
+  will have one or the other.}
+
+\subsubsection{Local Functions}
+
+\wss{As appropriate} \wss{These functions are for the purpose of specification.
+  They are not necessarily something that is going to be implemented
+  explicitly.  Even if they are implemented, they are not exported; they only
+  have local scope.}
+
+\newpage
+
 \bibliographystyle {plainnat}
 \bibliography {../../../refs/References}
 

--- a/docs/Design/SoftDetailedDes/MIS.tex
+++ b/docs/Design/SoftDetailedDes/MIS.tex
@@ -255,7 +255,8 @@ None
 \hline
 \textbf{Name} & \textbf{In} & \textbf{Out} & \textbf{Exceptions} \\
 \hline
-\wss{accessProg} & - & - & - \\
+didChangeAppLifeCycle & AppLifecycle & - & - \\
+scanReceipt & - & String - noPermissionException \\
 \hline
 \end{tabular}
 \end{center}
@@ -264,8 +265,7 @@ None
 
 \subsubsection{State Variables}
 
-\wss{Not all modules will have state variables.  State variables give the module
-  a memory.}
+AppLifecycle
 
 \subsubsection{Environment Variables}
 
@@ -274,8 +274,9 @@ User Display
 
 \subsubsection{Assumptions}
 
-\wss{Try to minimize assumptions and anticipate programmer errors via
-  exceptions, but for practical purposes assumptions are sometimes appropriate.}
+\begin{itemize}
+  \item Application will always be used on a device with a camera.
+\end{itemize}
 
 \subsubsection{Access Routine Semantics}
 

--- a/docs/Design/SoftDetailedDes/MIS.tex
+++ b/docs/Design/SoftDetailedDes/MIS.tex
@@ -251,21 +251,24 @@ None
 \subsubsection{Exported Access Programs}
 
 \begin{center}
-\begin{tabular}{p{2cm} p{4cm} p{4cm} p{2cm}}
-\hline
-\textbf{Name} & \textbf{In} & \textbf{Out} & \textbf{Exceptions} \\
-\hline
-didChangeAppLifeCycle & AppLifecycle & - & - \\
-scanReceipt & - & String - noPermissionException \\
-\hline
-\end{tabular}
+  \begin{tabular}{p{5cm} p{4cm} p{3cm} p{4cm}}
+  \hline
+  \textbf{Name} & \textbf{In} & \textbf{Out} & \textbf{Exceptions} \\
+  \hline
+  requestCameraPermission & - & - & - \\
+  didChangeAppLifeCycle & appLifecycle & - & - \\
+  scanReceipt & - & String & noPermissionException \\
+  \hline
+  \end{tabular}
 \end{center}
 
 \subsection{Semantics}
 
 \subsubsection{State Variables}
 
-AppLifecycle
+\textit{appLifecycle}: Tracks whether the application is running in the background or is active. \\
+\textit{isPermissionGranted}: Stores camera permission status. \\
+\textit{selectedCamera}: Stores data on which camera to use.
 
 \subsubsection{Environment Variables}
 
@@ -280,26 +283,40 @@ User Display
 
 \subsubsection{Access Routine Semantics}
 
-\noindent \wss{accessProg}():
+\noindent requestCameraPermission():
 \begin{itemize}
-\item transition: \wss{if appropriate} 
-\item output: \wss{if appropriate} 
-\item exception: \wss{if appropriate} 
+  \item transition: Request camera permission and update \textit{isPermissionGranted} accordingly.
+  \item output: none
+  \item exception: none
+  \end{itemize}
+
+\noindent didChangeAppLifeCycle(\textit{appLifecycle}):
+\begin{itemize}
+  \item transition: $transition := (\neg isPermissionGranted) \Rightarrow$ no action is performed $|$\\
+                    $(isPermissionGranted \land appLifecycle = active) \Rightarrow$ Turn on device camera $|$\\
+                    $(isPermissionGranted \land appLifecycle = inactive) \Rightarrow$ Turn off device camera
+  \item output: none
+  \item exception: none
 \end{itemize}
 
-\wss{A module without environment variables or state variables is unlikely to
-  have a state transition.  In this case a state transition can only occur if
-  the module is changing the state of another module.}
-
-\wss{Modules rarely have both a transition and an output.  In most cases you
-  will have one or the other.}
+\noindent scanReceipt():
+\begin{itemize}
+  \item transition: Display camera preview and interface for image capture.
+  \item output: $out := isPermissionGranted \Rightarrow$ take picture with camera and parse text
+  \item exception: $exc := (\neg isPermissionGranted) \Rightarrow$ noPermissionException
+\end{itemize}
 
 \subsubsection{Local Functions}
 
-\wss{As appropriate} \wss{These functions are for the purpose of specification.
-  They are not necessarily something that is going to be implemented
-  explicitly.  Even if they are implemented, they are not exported; they only
-  have local scope.}
+\noindent initializeCamera(availableCameras):
+\begin{itemize}
+  \item transition: Let $findBackFacingCamera = \forall cameras \exists camera \in cameras : camera.direction = back$ \\
+                    $transition := (\neg isPermissionGranted) \Rightarrow$ no action is performed $|$\\
+                    $isPermissionGranted \Rightarrow findBackFacingCamera(availableCameras) \Rightarrow $ \\
+                    $selectedCamera = camera$
+  \item output: none
+  \item exception: none
+\end{itemize}
 
 \newpage
 


### PR DESCRIPTION
14/01/24

# Issue #266: MIS for Receipt Vision Module

Adds a preliminary MIS For the Receipt Vision Module. Had some trouble formalizing stuff but I formalized what I could. Some samples are below:

![image](https://github.com/r-yeh/grocery-spending-tracker/assets/67233377/0c429623-ece9-4958-a032-415086e97ffd)
![image](https://github.com/r-yeh/grocery-spending-tracker/assets/67233377/2cce5f9e-cbca-4a62-9eb7-d4f799998b73)

### Changelog
- Receipt Vision MIS

### Notes
